### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/backend/apps/businesses/views.py
+++ b/backend/apps/businesses/views.py
@@ -8,6 +8,7 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.decorators import action
 from rest_framework.response import Response
 import math
+import logging
 from .models import Business, BusinessPhoto, BusinessReview
 from .serializers import BusinessSerializer, BusinessPhotoSerializer, BusinessReviewSerializer
 
@@ -236,7 +237,8 @@ class BusinessViewSet(viewsets.ModelViewSet):
             response['Content-Disposition'] = f'inline; filename="qr_code_{business.id}.png"'
             return response
         except Exception as e:
-            return Response({'error': f'Failed to generate QR code: {str(e)}'}, status=500)
+            logging.exception("Failed to generate QR code for business ID %s", business.id)
+            return Response({'error': 'Failed to generate QR code due to an internal error.'}, status=500)
     
     @action(detail=True, methods=['get'], permission_classes=[])
     def qr_url(self, request, pk=None):


### PR DESCRIPTION
Potential fix for [https://github.com/pixel-87/accessRating.info_backend/security/code-scanning/5](https://github.com/pixel-87/accessRating.info_backend/security/code-scanning/5)

To fix this problem, the code should avoid exposing the raw exception message to the user. Instead, it should log the exception details on the server for debugging purposes and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the exception (including the stack trace), and then returning a generic error message in the response. The changes should be made only in the `qr_code` method of the `BusinessViewSet` class in `backend/apps/businesses/views.py`. If the `logging` module is not already imported, it should be imported at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
